### PR TITLE
materials use id now

### DIFF
--- a/data/json/collectionList/filters.json
+++ b/data/json/collectionList/filters.json
@@ -101,7 +101,7 @@
 		"type": "filter",
 		"name": "all_material",
 		"display_name": "Type: material",
-		"display_key": "ident",
+		"display_key": [ "id", "ident" ],
 		"filter": { "jsonObject.type": { "$eq": "material" } }
 	},
 	{
@@ -411,9 +411,8 @@
 		"display_name": "Mod filter",
 		"display_key": "name",
 		"filter": { "$and": [ 
-        { "jsonObject.name_plural": { "$exists": true } },
-        { "jsonObject.spoils_in": { "$exists": false } },
-        { "jsonObject.container": { "$eq": "paper" } },
+        { "jsonObject.name": { "$type": "string" } },
+        { "jsonObject.type": { "$eq": "COMESTIBLE" } },
         { "fileName": { "$contains": "data\\mods\\Gourmand'sGraces\\" } }
     ] }
 	},

--- a/data/json/schemas/comestible.json
+++ b/data/json/schemas/comestible.json
@@ -311,9 +311,6 @@
             "title": "Freezing point",
             "default": 3,
             "description": "(Optional) Temperature in F at which item freezes, default is water (32F/0C)",
-            "options": {
-                "hidden": false
-            },
             "propertyOrder": 90
         },
         "proportional": {
@@ -431,9 +428,6 @@
             "title": "charges",
             "default": 3,
             "description": "Number of uses when spawned",
-            "options": {
-                "hidden": false
-            },
             "propertyOrder": 90
         },
         "stim": {
@@ -442,9 +436,6 @@
             "title": "stim",
             "default": 3,
             "description": "Stimulant effect",
-            "options": {
-                "hidden": false
-            },
             "propertyOrder": 90
         },
         "addiction_potential": {
@@ -453,9 +444,6 @@
             "title": "Addiction potential",
             "default": 3,
             "description": "Ability to cause addictions",
-            "options": {
-                "hidden": false
-            },
             "propertyOrder": 90
         },
         "healthy": {
@@ -464,9 +452,6 @@
             "title": "Healthy",
             "default": 1,
             "description": "How much it will affect your health.",
-            "options": {
-                "hidden": false
-            },
             "propertyOrder": 100
         },
         "calories": {"$ref": "#/definitions/calories"},

--- a/data/json/schemas/generaldefinitions.json
+++ b/data/json/schemas/generaldefinitions.json
@@ -930,7 +930,10 @@
               "format": "text",
               "title": "Single",
               "description": "The material",
-              "enum": [ "steel" ]
+              "filteredEnum": {
+                  "display_key": "id",
+                  "filter": { "jsonObject.type": { "$eq": "material" } }
+              }
           },
           {
               "type": "array",
@@ -953,7 +956,10 @@
                   "default": "steel",
                   "format": "text",
                   "description": "The material of this entry",
-                  "enum": [ "steel" ]
+                  "filteredEnum": {
+                      "display_key": "id",
+                      "filter": { "jsonObject.type": { "$eq": "material" } }
+                  }
               }
           }
       ]


### PR DESCRIPTION
updated the schema to reflect the fact that materials use id now instead of ident. Older 3d party mods still use ident, I've attempted to support that.